### PR TITLE
Changed flask debug env var to type string

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: sleep infinity
     environment:
       FLASK_APP: service:app
-      FLASK_DEBUG: True
+      FLASK_DEBUG: "True"
       PORT: 8000
       DATABASE_URI: postgresql://postgres:postgres@postgres:5432/postgres
     networks:


### PR DESCRIPTION
There was a minor issue in the docker-compose file of .devcontainer that was giving error while opening the folder in Vscode in a dev container. Manually using the `docker-compose up` command gave the following error:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.app.environment.FLASK_DEBUG contains true, which is an invalid type, it should be a string, number, or a null
```